### PR TITLE
Remove only instance of "gender non-conforming"

### DIFF
--- a/src/components/SEO/defaultSEO.js
+++ b/src/components/SEO/defaultSEO.js
@@ -1,7 +1,7 @@
 export const defaultSEO = {
     title: "LGBTQ Musical Theatre Network",
     description:
-        "Ring of Keys is a 501(c)3 artist service organization of queer women, trans, and gender non-conforming artists in musical theatre.",
+        "Ring of Keys is a 501(c)3 artist service organization of queer women, trans, and nonbinary artists in musical theatre.",
     image: {
         url: "https://www.datocms-assets.com/20110/1635698353-rok-metacard.jpg",
     },


### PR DESCRIPTION
This terminology is actually pretty medicalized back from the days when it was considered a mental disorder, so we're shifting to the autonomy-centered term "nonbinary", because it's a term that doesn't put your gender identity in the terms of how "weird" it is.

Most of the other instances are controlled in our CMS, but there was one that was hard-coded.