### PR TITLE
Fallback gracefully if user doesn't have an avatar

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -138,8 +138,10 @@ function SecondaryNav({ session, navOpen }) {
                                 <>
                                     <img
                                         src={
-                                            user.headshot.url +
-                                            "?fit=facearea&faceindex=1&facepad=5&mask=ellipse&w=100&h=100&"
+                                            user.headshot?.url
+                                            ? user.headshot?.url +
+                                              "?fit=facearea&faceindex=1&facepad=5&mask=ellipse&w=100&h=100&"
+                                            : "/img/blank_user_headshot.png"
                                         }
                                         alt={user.name + " headshot"}
                                     />

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -123,7 +123,10 @@ export default function Dashboard({ layoutData }) {
                     <section className={styles.infoSection}>
                         <div className={styles.avatarWrapper}>
                             <img
-                                src={`${user?.headshot?.url}?fit=facearea&faceindex=1&facepad=5&w=140&h=140&`}
+                                src={user.headshot?.url
+                                    ? user.headshot?.url +
+                                      "?fit=facearea&faceindex=1&facepad=5&mask=ellipse&w=100&h=100&"
+                                    : "/img/blank_user_headshot.png"}
                                 alt={user?.headshot?.title}
                                 className="avatar"
                             />


### PR DESCRIPTION
Right now, if a user doesn't have an avatar image associated with their profile, and they log in, they get a client-side error because we assume it's there. That's bad.