### PR TITLE
Switch package.json to "type": "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ring-of-keys",
   "private": true,
+  "type": "module",
   "description": "An artist directory for theatremakers",
   "version": "0.1.0",
   "author": "Frank Noirot",


### PR DESCRIPTION
Hoping to get Netlify Functions working again, don't know what has happened.